### PR TITLE
Add installation of /samples directory to CMakeLists.txt

### DIFF
--- a/audio_common/CMakeLists.txt
+++ b/audio_common/CMakeLists.txt
@@ -61,4 +61,9 @@ install(TARGETS
   DESTINATION lib/${PROJECT_NAME}
 )
 
+install(DIRECTORY
+  samples
+  DESTINATION share/${PROJECT_NAME}
+)
+
 ament_package()


### PR DESCRIPTION
Re-adds the installation of the `/samples` directory present in previous versions (<3.1.0) but omitted in the recent rewrite.