### PR TITLE
resample audio_player_node output for different sample rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Node to play the audio data obtained from the `audio` topic.
 - **channels**: The number of audio channels to play. Typically, `1` for mono and `2` for stereo. Default: `2`
   - The node automatically handles conversion between mono and stereo formats if needed.
 
+- **rate**: The output sample rate used to open the selected PortAudio output device. If set to `0`, the node uses the device default output sample rate. Incoming audio is resampled internally when its sample rate differs from this value. Default: `0`
+
 - **device**: The ID of the audio output device. A value of `-1` indicates that the default audio output device should be used. Default: `-1`
 
 #### ROS 2 Interfaces

--- a/audio_common/CMakeLists.txt
+++ b/audio_common/CMakeLists.txt
@@ -107,8 +107,15 @@ install(DIRECTORY include/
 )
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_clang_format REQUIRED)
   ament_clang_format(CONFIG_FILE .clang-format)
+
+  ament_add_gtest(sample_rate_converter_test
+    test/sample_rate_converter_test.cpp
+    src/audio_common/sample_rate_converter.cpp
+  )
+  target_include_directories(sample_rate_converter_test PRIVATE include)
 endif()
 
 ament_export_dependencies(${DEPENDENCIES})

--- a/audio_common/CMakeLists.txt
+++ b/audio_common/CMakeLists.txt
@@ -32,6 +32,7 @@ install(TARGETS
 
 # audio_player_node
 add_executable(audio_player_node
+  src/audio_common/sample_rate_converter.cpp
   src/audio_common/audio_player_node.cpp
   src/audio_player_main.cpp
 )

--- a/audio_common/include/audio_common/audio_player_node.hpp
+++ b/audio_common/include/audio_common/audio_player_node.hpp
@@ -26,7 +26,10 @@
 #include <memory>
 #include <portaudio.h>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
+#include <unordered_map>
 
+#include "audio_common/sample_rate_converter.hpp"
 #include "audio_common_msgs/msg/audio_stamped.hpp"
 
 namespace audio_common {
@@ -35,13 +38,16 @@ namespace audio_common {
  * @brief ROS 2 node that subscribes to stamped audio messages and plays them
  *        through a PortAudio output device.
  *
- * One PortAudio stream is opened per unique combination of sample format,
- * sample rate, and channel count.  Mono/stereo channel conversion is performed
- * automatically when the incoming channel count differs from the configured
- * output channel count.
+ * One PortAudio stream is opened per unique combination of input sample format,
+ * input sample rate, input channel count, output sample rate, and output channel
+ * count. Mono/stereo channel conversion and sample-rate conversion are
+ * performed automatically when the incoming audio differs from the configured
+ * output format.
  *
  * @par ROS 2 Parameters
  * - `channels` (int, default 2): Number of output audio channels.
+ * - `rate`     (int, default 0): Output sample rate. 0 selects the device
+ *              default output sample rate.
  * - `device`   (int, default -1): PortAudio output device index.
  *              -1 selects the system default output device.
  *
@@ -64,18 +70,25 @@ public:
   ~AudioPlayerNode() override;
 
 private:
+  struct PlaybackStream {
+    PaStream *stream;
+    int input_rate;
+    int output_rate;
+    SampleRateConverter sample_rate_converter;
+  };
+
   /// @brief ROS 2 subscription for incoming stamped audio messages.
   rclcpp::Subscription<audio_common_msgs::msg::AudioStamped>::SharedPtr
       audio_sub_;
 
   /**
-   * @brief Map from a stream-key string ("format_rate_channels") to the
-   *        corresponding open PortAudio stream.
+   * @brief Map from a stream-key string to the corresponding open PortAudio
+   *        stream and resampler state.
    *
-   * A new stream is created on demand the first time a particular
-   * format/rate/channel combination is encountered.
+   * A new stream is created on demand the first time a particular input/output
+   * format combination is encountered.
    */
-  std::unordered_map<std::string, PaStream *> stream_dict_;
+  std::unordered_map<std::string, PlaybackStream> stream_dict_;
 
   /// @brief Number of output audio channels (ROS 2 parameter "channels").
   int channels_;
@@ -83,6 +96,10 @@ private:
   /// @brief PortAudio output device index; -1 means the system default
   /// (ROS 2 parameter "device").
   int device_;
+
+  /// @brief Output sample rate; 0 means the selected device's default rate
+  /// (ROS 2 parameter "rate").
+  int rate_;
 
   /**
    * @brief Subscription callback – opens a stream if needed, then writes the
@@ -94,17 +111,18 @@ private:
 
   /**
    * @brief Write a block of typed audio samples to a PortAudio stream,
-   *        performing mono↔stereo channel conversion when necessary.
+    *        performing channel and sample-rate conversion when necessary.
    *
    * @tparam ContainerT Container type of the input sample buffer (e.g.
    *                    std::vector<int16_t>).
    * @param data        Input sample buffer received from the ROS 2 message.
    * @param channels    Channel count of the incoming @p data.
+  * @param rate        Sample rate of the incoming @p data.
    * @param chunk       Number of frames in @p data.
    * @param stream_key  Key used to look up the target stream in #stream_dict_.
    */
   template <typename ContainerT>
-  void write_data(const ContainerT &data, int channels, int chunk,
+  void write_data(const ContainerT &data, int channels, int rate, int chunk,
                   const std::string &stream_key);
 };
 

--- a/audio_common/include/audio_common/audio_player_node.hpp
+++ b/audio_common/include/audio_common/audio_player_node.hpp
@@ -39,8 +39,8 @@ namespace audio_common {
  *        through a PortAudio output device.
  *
  * One PortAudio stream is opened per unique combination of input sample format,
- * input sample rate, input channel count, output sample rate, and output channel
- * count. Mono/stereo channel conversion and sample-rate conversion are
+ * input sample rate, input channel count, output sample rate, and output
+ * channel count. Mono/stereo channel conversion and sample-rate conversion are
  * performed automatically when the incoming audio differs from the configured
  * output format.
  *
@@ -111,13 +111,13 @@ private:
 
   /**
    * @brief Write a block of typed audio samples to a PortAudio stream,
-    *        performing channel and sample-rate conversion when necessary.
+   *        performing channel and sample-rate conversion when necessary.
    *
    * @tparam ContainerT Container type of the input sample buffer (e.g.
    *                    std::vector<int16_t>).
    * @param data        Input sample buffer received from the ROS 2 message.
    * @param channels    Channel count of the incoming @p data.
-  * @param rate        Sample rate of the incoming @p data.
+   * @param rate        Sample rate of the incoming @p data.
    * @param chunk       Number of frames in @p data.
    * @param stream_key  Key used to look up the target stream in #stream_dict_.
    */

--- a/audio_common/include/audio_common/sample_rate_converter.hpp
+++ b/audio_common/include/audio_common/sample_rate_converter.hpp
@@ -1,0 +1,56 @@
+// MIT License
+//
+// Copyright (c) 2024 Miguel Ángel González Santamarta
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef AUDIO_COMMON__SAMPLE_RATE_CONVERTER
+#define AUDIO_COMMON__SAMPLE_RATE_CONVERTER
+
+#include <vector>
+
+namespace audio_common {
+
+class SampleRateConverter {
+public:
+  /**
+   * @brief Convert interleaved audio samples to a different sample rate.
+   *
+   * The converter keeps one frame of look-ahead between calls. Call flush()
+   * after the final input block to retrieve the retained final frame.
+   *
+   * @throws std::invalid_argument if a rate or channel count is not positive,
+   *         or if the input does not contain complete frames.
+   */
+  std::vector<float> convert(const std::vector<float> &input_data, int channels,
+                             int input_rate, int output_rate);
+
+  /**
+   * @brief Return the retained final frame and reset the converter state.
+   */
+  std::vector<float> flush();
+
+private:
+  double position_ = 0.0;
+  std::vector<float> previous_frame_;
+};
+
+} // namespace audio_common
+
+#endif

--- a/audio_common/package.xml
+++ b/audio_common/package.xml
@@ -10,6 +10,7 @@
     <test_depend>ament_lint_auto</test_depend>
     <test_depend>ament_clang_format</test_depend>
     <test_depend>ament_cmake_clang_format</test_depend>
+    <test_depend>ament_cmake_gtest</test_depend>
     <depend>ament_index_cpp</depend>
     <depend>audio_common_msgs</depend>
     <depend>portaudio19-dev</depend>

--- a/audio_common/src/audio_common/audio_player_node.cpp
+++ b/audio_common/src/audio_common/audio_player_node.cpp
@@ -122,8 +122,7 @@ void AudioPlayerNode::audio_callback(
                         : static_cast<int>(device_info->defaultSampleRate);
 
   if (msg->audio.info.rate <= 0 || output_rate <= 0) {
-    RCLCPP_ERROR(this->get_logger(),
-                 "Invalid sample rate: input=%d, output=%d",
+    RCLCPP_ERROR(this->get_logger(), "Invalid sample rate: input=%d, output=%d",
                  msg->audio.info.rate, output_rate);
     return;
   }
@@ -144,13 +143,12 @@ void AudioPlayerNode::audio_callback(
     outputParameters.suggestedLatency = device_info->defaultHighOutputLatency;
     outputParameters.hostApiSpecificStreamInfo = nullptr;
 
-    PaError err =
-        Pa_IsFormatSupported(nullptr, &outputParameters, output_rate);
+    PaError err = Pa_IsFormatSupported(nullptr, &outputParameters, output_rate);
 
     if (err != paFormatIsSupported) {
       RCLCPP_ERROR(this->get_logger(),
-                   "Output device %d does not support %d Hz: %s",
-                   output_device, output_rate, Pa_GetErrorText(err));
+                   "Output device %d does not support %d Hz: %s", output_device,
+                   output_rate, Pa_GetErrorText(err));
       return;
     }
 

--- a/audio_common/src/audio_common/audio_player_node.cpp
+++ b/audio_common/src/audio_common/audio_player_node.cpp
@@ -20,8 +20,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <limits>
 #include <memory>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -35,14 +40,37 @@
 using namespace audio_common;
 using std::placeholders::_1;
 
+namespace {
+
+template <typename T> float sample_to_float(T sample) {
+  return static_cast<float>(sample) /
+         (static_cast<float>(std::numeric_limits<T>::max()) + 1.0f);
+}
+
+template <> float sample_to_float<float>(float sample) { return sample; }
+
+template <> float sample_to_float<uint8_t>(uint8_t sample) {
+  return (static_cast<float>(sample) - 128.0f) / 128.0f;
+}
+
+} // namespace
+
 AudioPlayerNode::AudioPlayerNode() : Node("audio_player_node") {
   // Declare parameters
   this->declare_parameter<int>("channels", 2);
+  this->declare_parameter<int>("rate", 0);
   this->declare_parameter<int>("device", -1);
 
   // Get parameters
   this->channels_ = this->get_parameter("channels").as_int();
+  this->rate_ = this->get_parameter("rate").as_int();
   this->device_ = this->get_parameter("device").as_int();
+
+  if (this->channels_ <= 0) {
+    RCLCPP_ERROR(this->get_logger(), "Invalid output channel count: %d",
+                 this->channels_);
+    throw std::runtime_error("Invalid output channel count");
+  }
 
   // Initialize PortAudio
   PaError err = Pa_Initialize();
@@ -65,8 +93,8 @@ AudioPlayerNode::AudioPlayerNode() : Node("audio_player_node") {
 AudioPlayerNode::~AudioPlayerNode() {
   // Close all open streams and terminate PortAudio
   for (auto &stream_pair : this->stream_dict_) {
-    Pa_StopStream(stream_pair.second);
-    Pa_CloseStream(stream_pair.second);
+    Pa_StopStream(stream_pair.second.stream);
+    Pa_CloseStream(stream_pair.second.stream);
   }
   Pa_Terminate();
 }
@@ -74,60 +102,109 @@ AudioPlayerNode::~AudioPlayerNode() {
 void AudioPlayerNode::audio_callback(
     const audio_common_msgs::msg::AudioStamped::SharedPtr msg) {
 
-  // Create a unique stream key based on format, rate, and channels
+  PaDeviceIndex output_device =
+      (this->device_ >= 0) ? this->device_ : Pa_GetDefaultOutputDevice();
+
+  if (output_device == paNoDevice) {
+    RCLCPP_ERROR(this->get_logger(), "No PortAudio output device available");
+    return;
+  }
+
+  const PaDeviceInfo *device_info = Pa_GetDeviceInfo(output_device);
+  if (device_info == nullptr) {
+    RCLCPP_ERROR(this->get_logger(), "Invalid PortAudio output device: %d",
+                 output_device);
+    return;
+  }
+
+  int output_rate = this->rate_ > 0
+                        ? this->rate_
+                        : static_cast<int>(device_info->defaultSampleRate);
+
+  if (msg->audio.info.rate <= 0 || output_rate <= 0) {
+    RCLCPP_ERROR(this->get_logger(),
+                 "Invalid sample rate: input=%d, output=%d",
+                 msg->audio.info.rate, output_rate);
+    return;
+  }
+
+  // Create a unique stream key based on input and output audio formats
   std::string stream_key = std::to_string(msg->audio.info.format) + "_" +
                            std::to_string(msg->audio.info.rate) + "_" +
+                           std::to_string(msg->audio.info.channels) + "_" +
+                           std::to_string(output_rate) + "_" +
                            std::to_string(this->channels_);
 
   // Check if stream already exists, if not, create one
   if (this->stream_dict_.find(stream_key) == this->stream_dict_.end()) {
     PaStreamParameters outputParameters;
-    outputParameters.device =
-        (this->device_ >= 0) ? this->device_ : Pa_GetDefaultOutputDevice();
+    outputParameters.device = output_device;
     outputParameters.channelCount = this->channels_;
-    outputParameters.sampleFormat = msg->audio.info.format;
-    outputParameters.suggestedLatency =
-        Pa_GetDeviceInfo(outputParameters.device)->defaultHighOutputLatency;
+    outputParameters.sampleFormat = paFloat32;
+    outputParameters.suggestedLatency = device_info->defaultHighOutputLatency;
     outputParameters.hostApiSpecificStreamInfo = nullptr;
 
-    PaError err = Pa_OpenStream(&this->stream_dict_[stream_key], nullptr,
-                                &outputParameters, msg->audio.info.rate, 1024,
-                                paClipOff, nullptr, nullptr);
+    PaError err =
+        Pa_IsFormatSupported(nullptr, &outputParameters, output_rate);
+
+    if (err != paFormatIsSupported) {
+      RCLCPP_ERROR(this->get_logger(),
+                   "Output device %d does not support %d Hz: %s",
+                   output_device, output_rate, Pa_GetErrorText(err));
+      return;
+    }
+
+    PlaybackStream playback_stream{};
+    playback_stream.stream = nullptr;
+    playback_stream.input_rate = msg->audio.info.rate;
+    playback_stream.output_rate = output_rate;
+
+    err = Pa_OpenStream(&playback_stream.stream, nullptr, &outputParameters,
+                        output_rate, 1024, paClipOff, nullptr, nullptr);
 
     if (err != paNoError) {
       RCLCPP_ERROR(this->get_logger(), "Failed to open audio stream: %s",
                    Pa_GetErrorText(err));
       return;
     }
-    Pa_StartStream(this->stream_dict_[stream_key]);
+
+    err = Pa_StartStream(playback_stream.stream);
+    if (err != paNoError) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to start audio stream: %s",
+                   Pa_GetErrorText(err));
+      Pa_CloseStream(playback_stream.stream);
+      return;
+    }
+
+    this->stream_dict_[stream_key] = playback_stream;
   }
 
   // Write audio from ROS 2 msg
   switch (msg->audio.info.format) {
   case paFloat32:
     this->write_data(msg->audio.audio_data.float32_data,
-                     msg->audio.info.channels, msg->audio.info.chunk,
-                     stream_key);
+                     msg->audio.info.channels, msg->audio.info.rate,
+                     msg->audio.info.chunk, stream_key);
     break;
 
   case paInt32:
     this->write_data(msg->audio.audio_data.int32_data, msg->audio.info.channels,
-                     msg->audio.info.chunk, stream_key);
+                     msg->audio.info.rate, msg->audio.info.chunk, stream_key);
     break;
 
   case paInt16:
     this->write_data(msg->audio.audio_data.int16_data, msg->audio.info.channels,
-                     msg->audio.info.chunk, stream_key);
+                     msg->audio.info.rate, msg->audio.info.chunk, stream_key);
     break;
 
   case paInt8:
     this->write_data(msg->audio.audio_data.int8_data, msg->audio.info.channels,
-                     msg->audio.info.chunk, stream_key);
+                     msg->audio.info.rate, msg->audio.info.chunk, stream_key);
     break;
 
   case paUInt8:
     this->write_data(msg->audio.audio_data.uint8_data, msg->audio.info.channels,
-                     msg->audio.info.chunk, stream_key);
+                     msg->audio.info.rate, msg->audio.info.chunk, stream_key);
     break;
   default:
     RCLCPP_ERROR(this->get_logger(), "Unsupported format");
@@ -137,50 +214,84 @@ void AudioPlayerNode::audio_callback(
 
 template <typename ContainerT>
 void AudioPlayerNode::write_data(const ContainerT &input_data, int channels,
-                                 int chunk, const std::string &stream_key) {
+                                 int rate, int chunk,
+                                 const std::string &stream_key) {
 
-  using T = typename ContainerT::value_type;
-  std::vector<T> data;
+  auto stream_it = this->stream_dict_.find(stream_key);
+  if (stream_it == this->stream_dict_.end()) {
+    RCLCPP_ERROR(this->get_logger(), "Audio stream not found");
+    return;
+  }
+
+  if (channels <= 0 || chunk <= 0) {
+    RCLCPP_WARN(this->get_logger(), "Invalid audio data shape");
+    return;
+  }
+
+  const size_t input_frames = static_cast<size_t>(chunk);
+  const size_t required_input_samples = input_frames * channels;
+
+  if (input_data.size() < required_input_samples) {
+    RCLCPP_WARN(this->get_logger(),
+                "Insufficient data (%zu) for requested chunk size (%zu).",
+                input_data.size(), required_input_samples);
+    return;
+  }
+
+  std::vector<float> data(input_frames * this->channels_);
 
   // Handle mono-to-stereo or stereo-to-mono conversions if necessary
   if (channels != this->channels_) {
     if (channels == 1 && this->channels_ == 2) {
       // Mono to stereo conversion
-      data.resize(input_data.size() * 2);
-      for (size_t i = 0; i < input_data.size(); ++i) {
-        data[2 * i] = input_data[i];
-        data[2 * i + 1] = input_data[i];
+      for (size_t i = 0; i < input_frames; ++i) {
+        const float sample = sample_to_float(input_data[i]);
+        data[2 * i] = sample;
+        data[2 * i + 1] = sample;
       }
     } else if (channels == 2 && this->channels_ == 1) {
       // Stereo to mono conversion
-      data.resize(input_data.size() / 2);
-      for (size_t i = 0; i < data.size(); ++i) {
-        data[i] =
-            static_cast<T>((input_data[2 * i] + input_data[2 * i + 1]) / 2);
+      for (size_t i = 0; i < input_frames; ++i) {
+        data[i] = (sample_to_float(input_data[2 * i]) +
+                   sample_to_float(input_data[2 * i + 1])) /
+                  2.0f;
       }
+    } else {
+      RCLCPP_WARN(this->get_logger(),
+                  "Unsupported channel conversion from %d to %d channels.",
+                  channels, this->channels_);
+      return;
     }
   } else {
     // No conversion needed
-    data.assign(input_data.begin(), input_data.end());
+    for (size_t i = 0; i < data.size(); ++i) {
+      data[i] = sample_to_float(input_data[i]);
+    }
   }
 
-  // Make sure chunk size is correct for frames (not samples)
-  if (data.size() < static_cast<size_t>(chunk * this->channels_)) {
-    RCLCPP_WARN(this->get_logger(),
-                "Insufficient data (%ld) for requested chunk size (%d).",
-                data.size(), chunk * this->channels_);
+  const float *write_data = data.data();
+  size_t total_frames = input_frames;
+  std::vector<float> resampled_data;
+
+  if (rate != stream_it->second.output_rate) {
+    resampled_data = stream_it->second.sample_rate_converter.convert(
+        data, this->channels_, rate, stream_it->second.output_rate);
+    write_data = resampled_data.data();
+    total_frames = resampled_data.size() / this->channels_;
+  }
+
+  if (total_frames == 0) {
     return;
   }
 
   // Write in smaller blocks to reduce underrun risk
   size_t frames_written = 0;
-  size_t total_frames = chunk;
   const size_t max_block = 1024;
 
   while (frames_written < total_frames) {
     size_t frames_to_write = std::min(max_block, total_frames - frames_written);
-    PaError err = Pa_WriteStream(this->stream_dict_[stream_key],
-                                 data.data() + frames_written * this->channels_,
+    PaError err = Pa_WriteStream(stream_it->second.stream,
+                                 write_data + frames_written * this->channels_,
                                  frames_to_write);
 
     if (err == paOutputUnderflowed) {

--- a/audio_common/src/audio_common/sample_rate_converter.cpp
+++ b/audio_common/src/audio_common/sample_rate_converter.cpp
@@ -1,0 +1,95 @@
+// MIT License
+//
+// Copyright (c) 2024 Miguel Ángel González Santamarta
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "audio_common/sample_rate_converter.hpp"
+
+#include <cmath>
+#include <stdexcept>
+#include <utility>
+
+using namespace audio_common;
+
+std::vector<float>
+SampleRateConverter::convert(const std::vector<float> &input_data, int channels,
+                             int input_rate, int output_rate) {
+
+  if (channels <= 0) {
+    throw std::invalid_argument("channels must be positive");
+  }
+  if (input_rate <= 0 || output_rate <= 0) {
+    throw std::invalid_argument("sample rates must be positive");
+  }
+  if (input_data.size() % static_cast<size_t>(channels) != 0) {
+    throw std::invalid_argument("input data must contain complete frames");
+  }
+
+  std::vector<float> output_data;
+  const size_t input_frames = input_data.size() / channels;
+  if (input_frames == 0) {
+    return output_data;
+  }
+
+  output_data.reserve(
+      static_cast<size_t>(std::ceil(static_cast<double>(input_frames) *
+                                    output_rate / input_rate)) *
+      channels);
+
+  std::vector<float> source_data;
+  source_data.reserve(input_data.size() + this->previous_frame_.size());
+
+  if (!this->previous_frame_.empty()) {
+    source_data.insert(source_data.end(), this->previous_frame_.begin(),
+                       this->previous_frame_.end());
+  }
+
+  source_data.insert(source_data.end(), input_data.begin(), input_data.end());
+
+  const size_t source_frames = source_data.size() / channels;
+  const double step = static_cast<double>(input_rate) / output_rate;
+
+  while (this->position_ + 1.0 < static_cast<double>(source_frames)) {
+    const size_t frame_index = static_cast<size_t>(this->position_);
+    const double fraction = this->position_ - frame_index;
+
+    for (int channel = 0; channel < channels; ++channel) {
+      const float current_sample =
+          source_data[frame_index * channels + channel];
+      const float next_sample =
+          source_data[(frame_index + 1) * channels + channel];
+      output_data.push_back(static_cast<float>(
+          current_sample + (next_sample - current_sample) * fraction));
+    }
+
+    this->position_ += step;
+  }
+
+  this->previous_frame_.assign(input_data.end() - channels, input_data.end());
+  this->position_ -= static_cast<double>(source_frames - 1);
+
+  return output_data;
+}
+
+std::vector<float> SampleRateConverter::flush() {
+  std::vector<float> output_data = std::move(this->previous_frame_);
+  this->position_ = 0.0;
+  return output_data;
+}

--- a/audio_common/test/sample_rate_converter_test.cpp
+++ b/audio_common/test/sample_rate_converter_test.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <vector>
+
+#include "audio_common/sample_rate_converter.hpp"
+
+namespace audio_common {
+
+TEST(SampleRateConverterTest, RejectsInvalidArguments) {
+  SampleRateConverter converter;
+
+  EXPECT_THROW(converter.convert({1.0F}, 0, 44100, 48000),
+               std::invalid_argument);
+  EXPECT_THROW(converter.convert({1.0F}, 1, 0, 48000), std::invalid_argument);
+  EXPECT_THROW(converter.convert({1.0F}, 1, 44100, 0), std::invalid_argument);
+  EXPECT_THROW(converter.convert({1.0F, 2.0F}, 3, 44100, 48000),
+               std::invalid_argument);
+}
+
+TEST(SampleRateConverterTest, FlushReturnsFinalFrameAndResetsState) {
+  SampleRateConverter converter;
+
+  EXPECT_EQ(converter.convert({1.0F, 2.0F}, 1, 44100, 44100),
+            (std::vector<float>{1.0F}));
+  EXPECT_EQ(converter.flush(), (std::vector<float>{2.0F}));
+  EXPECT_TRUE(converter.flush().empty());
+}
+
+TEST(SampleRateConverterTest, PreservesChunkContinuity) {
+  SampleRateConverter converter;
+
+  const auto first = converter.convert({0.0F, 1.0F}, 1, 2, 4);
+  const auto second = converter.convert({2.0F, 3.0F}, 1, 2, 4);
+  const auto final = converter.flush();
+
+  EXPECT_EQ(first, (std::vector<float>{0.0F, 0.5F}));
+  EXPECT_EQ(second, (std::vector<float>{1.0F, 1.5F, 2.0F, 2.5F}));
+  EXPECT_EQ(final, (std::vector<float>{3.0F}));
+}
+
+TEST(SampleRateConverterTest, ConvertsInterleavedChannels) {
+  SampleRateConverter converter;
+
+  const auto output = converter.convert({0.0F, 10.0F, 2.0F, 12.0F}, 2, 2, 1);
+  const auto final = converter.flush();
+
+  EXPECT_EQ(output, (std::vector<float>{0.0F, 10.0F}));
+  EXPECT_EQ(final, (std::vector<float>{2.0F, 12.0F}));
+}
+
+} // namespace audio_common


### PR DESCRIPTION
**Summary**

This PR adds sample-rate conversion to `audio_player_node`, allowing incoming audio to be played through output devices that use a different sample rate.

This enables Text-to-Speech audio generated at 16 kHz to play on speakers that only support 44.1 kHz or 48 kHz output.

**Changes**

- Added SampleRateConverter for converting to different sample rates.
- Added the rate parameter to configure the output sample rate.
- Falls back to the PortAudio device default sample rate when rate is 0.
- Added per-format stream handling for different input and output sample-rate combinations.
- Added tests for the SampleRateConverter.
- Registered the new test target and dependencies in CMake and package.xml.